### PR TITLE
Dep override fix

### DIFF
--- a/golang/dep/dep-override/Gopkg.lock
+++ b/golang/dep/dep-override/Gopkg.lock
@@ -140,6 +140,17 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:98b8ffea3fbb87f7bbaabca43d62f3a3623e6e037f1fe5b88a5895d742aee502"
+  name = "github.com/srcclr/efda"
+  packages = [
+    "golang/dep/dep-override/sub",
+    "golang/dep/dep-override/sub2",
+  ]
+  pruneopts = ""
+  revision = "03020952c95ae0fccc3eff6899071aeea0f95f96"
+
+[[projects]]
+  branch = "master"
   digest = "1:fb9c60108aa8a0c8571f568c05fe8f3be347cf30b6b05d86beda7d7223ff88c8"
   name = "golang.org/x/sys"
   packages = ["unix"]
@@ -155,6 +166,8 @@
     "github.com/russellhaering/gosaml2",
     "github.com/simeji/jid",
     "github.com/square/go-jose",
+    "github.com/srcclr/efda/golang/dep/dep-override/sub",
+    "github.com/srcclr/efda/golang/dep/dep-override/sub2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/golang/dep/dep-override/main.go
+++ b/golang/dep/dep-override/main.go
@@ -2,8 +2,8 @@ package main
 
 import "fmt"
 import "github.com/google/go-querystring/query"
-import "github.com/srcclr/example-go-golangdep/sub"
-import "github.com/srcclr/example-go-golangdep/sub2"
+import "github.com/srcclr/efda/golang/dep/dep-override/sub"
+import "github.com/srcclr/efda/golang/dep/dep-override/sub2"
 import "github.com/russellhaering/gosaml2"
 
 type Options struct {


### PR DESCRIPTION
Simple update to the Go dep-override example so that it is self contained. Previously the `main.go` refers to components in `srcclr/example-go-golangdep`, this is changed to refer to `srcclr/efda/golang/dep/dep-override` itself.